### PR TITLE
Reimplement assertions removed in PHPUnit 10/12

### DIFF
--- a/src/Codeception/Util/Shared/InheritedAsserts.php
+++ b/src/Codeception/Util/Shared/InheritedAsserts.php
@@ -51,7 +51,13 @@ trait InheritedAsserts
      */
     protected function assertClassHasStaticAttribute(string $attributeName, string $className, string $message = '')
     {
-        Assert::assertClassHasStaticAttribute($attributeName, $className, $message);
+        trigger_error(__FUNCTION__ . ' was removed from PHPUnit since PHPUnit 10', E_USER_DEPRECATED);
+
+        if (method_exists(Assert::class, 'assertClassHasStaticAttribute')) {
+            Assert::assertClassHasStaticAttribute($attributeName, $className, $message);
+        } else {
+            Assert::assertTrue(self::hasStaticAttribute($attributeName, $className), $message);
+        }
     }
 
     /**
@@ -75,7 +81,11 @@ trait InheritedAsserts
     {
         trigger_error(__FUNCTION__ . ' was removed from PHPUnit since PHPUnit 10', E_USER_DEPRECATED);
 
-        Assert::assertClassNotHasStaticAttribute($attributeName, $className, $message);
+        if (method_exists(Assert::class, 'assertClassNotHasStaticAttribute')) {
+            Assert::assertClassNotHasStaticAttribute($attributeName, $className, $message);
+        } else {
+            Assert::assertFalse(self::hasStaticAttribute($attributeName, $className), $message);
+        }
     }
 
     /**
@@ -1199,5 +1209,22 @@ trait InheritedAsserts
     protected function markTestSkipped(string $message = '')
     {
         Assert::markTestSkipped($message);
+    }
+
+    /**
+     * @see https://github.com/sebastianbergmann/phpunit/blob/9.6/src/Framework/Constraint/Object/ClassHasStaticAttribute.php
+     */
+    private static function hasStaticAttribute(string $attributeName, string $className)
+    {
+        try {
+            $class = new \ReflectionClass($className);
+
+            if ($class->hasProperty($attributeName)) {
+                return $class->getProperty($attributeName)->isStatic();
+            }
+        } catch (ReflectionException $e) {
+        }
+
+        return false;
     }
 }

--- a/src/Codeception/Util/Shared/InheritedAsserts.php
+++ b/src/Codeception/Util/Shared/InheritedAsserts.php
@@ -7,6 +7,8 @@ namespace Codeception\Util\Shared;
 use Codeception\PHPUnit\TestCase;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Constraint\Constraint as PHPUnitConstraint;
+use PHPUnit\Framework\Constraint\LogicalNot;
+use PHPUnit\Framework\Constraint\StringMatchesFormatDescription;
 
 trait InheritedAsserts
 {
@@ -1082,7 +1084,15 @@ trait InheritedAsserts
      */
     protected function assertStringNotMatchesFormat(string $format, string $string, string $message = '')
     {
-        Assert::assertStringNotMatchesFormat($format, $string, $message);
+        trigger_error(__FUNCTION__ . ' was removed from PHPUnit since PHPUnit 12', E_USER_DEPRECATED);
+
+        if (method_exists(Assert::class, 'assertStringNotMatchesFormat')) {
+            Assert::assertStringNotMatchesFormat($format, $string, $message);
+        } else {
+            $constraint = new LogicalNot(new StringMatchesFormatDescription($format));
+
+            Assert::assertThat($string, $constraint, $message);
+        }
     }
 
     /**
@@ -1090,7 +1100,21 @@ trait InheritedAsserts
      */
     protected function assertStringNotMatchesFormatFile(string $formatFile, string $string, string $message = '')
     {
-        Assert::assertStringNotMatchesFormatFile($formatFile, $string, $message);
+        trigger_error(__FUNCTION__ . ' was removed from PHPUnit since PHPUnit 12', E_USER_DEPRECATED);
+
+        if (method_exists(Assert::class, 'assertStringNotMatchesFormatFile')) {
+            Assert::assertStringNotMatchesFormatFile($formatFile, $string, $message);
+        } else {
+            Assert::assertFileExists($formatFile);
+
+            $constraint = new LogicalNot(
+                new StringMatchesFormatDescription(
+                    file_get_contents($formatFile)
+                )
+            );
+
+            Assert::assertThat($string, $constraint, $message);
+        }
     }
 
     /**


### PR DESCRIPTION
I noticed some missing assertions when trying to add missing tests to https://github.com/Codeception/module-asserts

Removed in PHPUnit 10 (https://github.com/sebastianbergmann/phpunit/issues/4602):
* `assertClassHasStaticAttribute`
* `assertClassNotHasStaticAttribute`

Removed in PHPUnit 12 (https://github.com/sebastianbergmann/phpunit/issues/5473)
* `assertStringNotMatchesFormat`
* `assertStringNotMatchesFormatFile`